### PR TITLE
Remove unsafe local variables

### DIFF
--- a/darkokai-theme.el
+++ b/darkokai-theme.el
@@ -5714,8 +5714,6 @@ Also affects 'linum-mode' background."
 
 ;; Local Variables:
 ;; no-byte-compile: t
-;; eval: (when (fboundp 'rainbow-mode) (rainbow-mode 1))
-;; eval: (when (fboundp 'aggressive-indent-mode) (aggressive-indent-mode -1))
 ;; fill-column: 95
 ;; End:
 


### PR DESCRIPTION
It's bad practice to throw unsafe "eval" forms in local variables.

A neater alternative is to handle this in your emacs config:

``` el
(defvar sanityinc/theme-mode-hook nil
  "Hook triggered when editing a theme file.")

(defun sanityinc/run-theme-mode-hooks-if-theme ()
  "Run `sanityinc/theme-mode-hook' if this appears to a theme."
  (when (string-match "\\(color-theme-\\|-theme\\.el\\)" (buffer-name))
    (run-hooks 'sanityinc/theme-mode-hook)))

(add-hook 'emacs-lisp-mode-hook 'sanityinc/run-theme-mode-hooks-if-theme)
```

then

``` el
(add-hook 'sanityinc/theme-mode-hook 'rainbow-mode)
(add-hook 'sanityinc/theme-mode-hook '(lambda () (aggressive-indent-mode -1)))
```
