### PR TITLE
Use different colour for mu4e-replied-face

### DIFF
--- a/darkokai-theme.el
+++ b/darkokai-theme.el
@@ -3769,9 +3769,9 @@ Also affects 'linum-mode' background."
                                  :weight bold))))
 
    `(mu4e-replied-face
-     ((,class (:inherit font-lock-builtin-face
+     ((,class (:inherit font-lock-function-name-face
                         :weight normal))
-      (,terminal-class (:inherit font-lock-builtin-face
+      (,terminal-class (:inherit font-lock-function-face
                                  :weight normal))))
 
    `(mu4e-system-face


### PR DESCRIPTION
First of all awesome theme, ❤️ing it.

The current colours for mu4e's replied and unread faces are the same, and the only way to distinguish is from the weight. This is pretty confusing as it makes you wonder whether you've read/replied to the mail or not.

<img width="579" alt="screen shot 2017-07-12 at 6 29 04 pm" src="https://user-images.githubusercontent.com/224216/28142785-7fa8f91c-6730-11e7-8748-54fd69e573a2.png">

This changes the font face for replied mail to the `font-lock-function-name-face`s which is green and feels like a good indicator of action that has been completed (I realize that this might be bad from a usability perspective for red/green colour blind people, but I wasn't sure what other colour would work better; happy to take suggestions).

As a side question, if feels a little weird that the `font-lock-*-face`s are being re-used/inherited from for colouring purposes, would it make sense in the future to create colour based font-faces that can be used as base building blocks instead of these prog specific ones?